### PR TITLE
Latest VisVersion as static variable

### DIFF
--- a/csharp/src/Vista.SDK/Defaults.cs
+++ b/csharp/src/Vista.SDK/Defaults.cs
@@ -1,6 +1,0 @@
-﻿namespace Vista.SDK;
-
-public static class Defaults
-{
-    public static readonly VisVersion VisVersion = VisVersion.v3_4a;
-}

--- a/csharp/src/Vista.SDK/VIS.cs
+++ b/csharp/src/Vista.SDK/VIS.cs
@@ -26,6 +26,8 @@ public static partial class VisVersionExtensions { }
 
 public sealed class VIS : IVIS
 {
+    public static readonly VisVersion LatestVisVersion = VisVersion.v3_5a;
+
     private readonly MemoryCache _gmodDtoCache;
     private readonly MemoryCache _gmodCache;
     private readonly MemoryCache _codebooksDtoCache;

--- a/js/src/vista-sdk/lib/Defaults.ts
+++ b/js/src/vista-sdk/lib/Defaults.ts
@@ -1,5 +1,0 @@
-import { VisVersion } from './VisVersion';
-
-export class Defaults {
-  public static visVersion = VisVersion.v3_4a;
-}

--- a/js/src/vista-sdk/lib/VIS.ts
+++ b/js/src/vista-sdk/lib/VIS.ts
@@ -10,6 +10,8 @@ import { Codebooks } from "./Codebooks";
 export class VIS {
     public static readonly instance = new VIS();
 
+    public static readonly LatestVisVersion: VisVersion = VisVersion.v3_5a;
+
     private readonly _gmodDtoCache: LRUCache<VisVersion, Promise<GmodDto>>;
     private readonly _gmodCache: LRUCache<VisVersion, Gmod>;
     private readonly _codebooksDtoCache: LRUCache<

--- a/js/src/vista-sdk/lib/index.ts
+++ b/js/src/vista-sdk/lib/index.ts
@@ -19,7 +19,6 @@ import { GmodNodeMetadata } from "./types/GmodNode";
 import { ParsingState } from "./types/LocalId";
 import { PmodInfo } from "./types/Pmod";
 import { Client } from "./Client";
-import { Defaults } from "./Defaults";
 import { PmodNode } from "./PmodNode";
 import { UniversalIdParser } from "./UniversalId.Parsing";
 import {
@@ -61,8 +60,6 @@ export { Gmod, GmodNode, GmodPath };
 export { Pmod, PmodNode };
 // Client
 export { Client };
-// Defaults
-export { Defaults };
 
 // Transport
 export {

--- a/js/src/vista-sdk/lib/transport/json/time-series-data/Extensions.ts
+++ b/js/src/vista-sdk/lib/transport/json/time-series-data/Extensions.ts
@@ -1,4 +1,3 @@
-import { Defaults, VIS } from "../../..";
 import { DataChannelId, ShipId, TimeSeries } from "../../domain";
 import { TimeSeriesDto } from "./TimeSeriesData";
 


### PR DESCRIPTION
Expose latest vis version as variable as opposed to `Defaults.VisVersion`, as that would probably be application specific. LatestVisVersion is the latest stable versioned that the SDK supports