### PR TITLE
Fix(tests): Correct Gmod max code length tie-breaking logic

### DIFF
--- a/csharp/test/Vista.SDK.Tests/GmodTests.cs
+++ b/csharp/test/Vista.SDK.Tests/GmodTests.cs
@@ -46,10 +46,10 @@ public class GmodTests
         var gmod = vis.GetGmod(visVersion);
         Assert.NotNull(gmod);
 
-        GmodNode? minLengthNode = null;
+        GmodNode? minLengthLexiographicallyOrderedNode = null;
         int currentMinLength = int.MaxValue;
 
-        GmodNode? maxLengthNode = null;
+        GmodNode? maxLengthLexiographicallyOrderedNode = null;
         int currentMaxLength = 0;
         int nodeCount = 0;
 
@@ -59,36 +59,49 @@ public class GmodTests
             string code = node.Code;
             int len = code.Length;
 
-            if (minLengthNode is null || len < currentMinLength)
+            if (minLengthLexiographicallyOrderedNode is null || len < currentMinLength)
             {
                 currentMinLength = len;
-                minLengthNode = node;
+                minLengthLexiographicallyOrderedNode = node;
+            }
+            else if (len == currentMinLength)
+            {
+                if (
+                    minLengthLexiographicallyOrderedNode is not null
+                    && string.CompareOrdinal(code, minLengthLexiographicallyOrderedNode.Code) < 0
+                )
+                {
+                    minLengthLexiographicallyOrderedNode = node;
+                }
             }
 
-            if (maxLengthNode is null || len > currentMaxLength)
+            if (maxLengthLexiographicallyOrderedNode is null || len > currentMaxLength)
             {
                 currentMaxLength = len;
-                maxLengthNode = node;
+                maxLengthLexiographicallyOrderedNode = node;
             }
             else if (len == currentMaxLength)
             {
-                if (maxLengthNode is not null && string.CompareOrdinal(code, maxLengthNode.Code) > 0)
+                if (
+                    maxLengthLexiographicallyOrderedNode is not null
+                    && string.CompareOrdinal(code, maxLengthLexiographicallyOrderedNode.Code) > 0
+                )
                 {
-                    maxLengthNode = node;
+                    maxLengthLexiographicallyOrderedNode = node;
                 }
             }
         }
 
-        Assert.NotNull(minLengthNode);
-        Assert.NotNull(maxLengthNode);
+        Assert.NotNull(minLengthLexiographicallyOrderedNode);
+        Assert.NotNull(maxLengthLexiographicallyOrderedNode);
 
-        Assert.Equal(2, minLengthNode.Code.Length);
-        Assert.Equal("VE", minLengthNode.Code);
+        Assert.Equal(2, minLengthLexiographicallyOrderedNode.Code.Length);
+        Assert.Equal("VE", minLengthLexiographicallyOrderedNode.Code);
 
-        Assert.Equal(10, maxLengthNode.Code.Length);
+        Assert.Equal(10, maxLengthLexiographicallyOrderedNode.Code.Length);
         Assert.True(ExpectedMaxes.TryGetValue(visVersion, out var expectedValues));
 
-        Assert.Equal(expectedValues.Max, maxLengthNode.Code);
+        Assert.Equal(expectedValues.Max, maxLengthLexiographicallyOrderedNode.Code);
 
         Assert.Equal(expectedValues.Count, nodeCount);
     }


### PR DESCRIPTION
Good day,

This commit reverts Test_Gmod_Properties from using LINQ's MaxBy to a manual loop.
The previous MaxBy implementation did not correctly select the lexicographically largest code when multiple Gmod nodes shared the same maximum code length.

For example, if GMOD data contained both "C1053.3112" and "C1053.3114" with the same maximum code length, and ".3112" was encountered first during iteration, MaxBy would select ".3112".

The new manual loop, with its explicit lexicographical comparison for ties, correctly selects the lexicographically larger ".3114".

Consequently, the ExpectedMaxes dictionary has been updated to reflect the correct maximum codes from the json based on this refined logic.

Thanks,