### PR TITLE
Fix: Correct character-to-digit conversion in C# LocationBuilder.WithLocation()

### DIFF
--- a/csharp/src/Vista.SDK/LocationBuilder.cs
+++ b/csharp/src/Vista.SDK/LocationBuilder.cs
@@ -38,7 +38,7 @@ public sealed record LocationBuilder
             if (char.IsDigit(ch))
             {
                 if (n is null)
-                    n = ch;
+                    n = ch - '0';
                 else
                 {
                     if (!Locations.TryParseInt(span, 0, i + 1, out var num))

--- a/csharp/src/Vista.SDK/Locations.cs
+++ b/csharp/src/Vista.SDK/Locations.cs
@@ -207,7 +207,7 @@ public sealed class Locations
 
                 if (digitStartIndex is null)
                 {
-                    number = ch;
+                    number = ch - '0'; 
                     digitStartIndex = i;
                 }
                 else

--- a/csharp/test/Vista.SDK.Tests/LocationsTests.cs
+++ b/csharp/test/Vista.SDK.Tests/LocationsTests.cs
@@ -23,7 +23,7 @@ public class LocationsTests
     {
         var values = Enum.GetValues(typeof(LocationGroup)).Cast<int>().ToArray();
         Assert.Equal(values.Length, new HashSet<int>(values).Count);
-        Assert.Equal(5, values.Length); // If this changes, wee need to chaneg the way LocationCharDict is used
+        Assert.Equal(5, values.Length); // If this changes, we need to change the way LocationCharDict is used
         Assert.Equal(0, (int)LocationGroup.Number);
         for (int i = 0; i < values.Length - 1; i++) // Start at one
         {
@@ -119,6 +119,34 @@ public class LocationsTests
         Assert.Equal('U', builder.Vertical);
         Assert.Equal('I', builder.Transverse);
         Assert.Equal('F', builder.Longitudinal);
+    }
+
+    [Fact]
+    public void Test_LocationBuilder_WithLocation_SingleDigit()
+    {
+        var locations = VIS.Instance.GetLocations(VisVersion.v3_4a);
+
+        // Test single digit location parsing
+        var builder1 = LocationBuilder.Create(locations).WithLocation(new Location("1"));
+        Assert.Equal(1, builder1.Number);
+        Assert.Equal("1", builder1.ToString());
+
+        var builder5 = LocationBuilder.Create(locations).WithLocation(new Location("5"));
+        Assert.Equal(5, builder5.Number);
+        Assert.Equal("5", builder5.ToString());
+
+        var builder9 = LocationBuilder.Create(locations).WithLocation(new Location("9"));
+        Assert.Equal(9, builder9.Number);
+        Assert.Equal("9", builder9.ToString());
+
+        // Test single digit with characters
+        var builderMixed = LocationBuilder.Create(locations).WithLocation(new Location("1FIPU"));
+        Assert.Equal(1, builderMixed.Number);
+        Assert.Equal('P', builderMixed.Side);
+        Assert.Equal('U', builderMixed.Vertical);
+        Assert.Equal('I', builderMixed.Transverse);
+        Assert.Equal('F', builderMixed.Longitudinal);
+        Assert.Equal("1FIPU", builderMixed.ToString());
     }
 
     [Fact]


### PR DESCRIPTION
Hi,

Except if I am wrong, I guess this is a bug while it might have no impact at the moment.

**The issue:**
- Used `n = ch` instead of `n = ch - '0'` for single-digit parsing
- This stored ASCII values (e.g., '1' → 49) instead of numeric values (1)

**The fix:**
- Changed to proper character-to-digit conversion
- Added tests for single-digit cases to prevent regression

Best regards,
