### PR TITLE
fix: TimeSeriesData validation bugs

### DIFF
--- a/csharp/src/Vista.SDK/Transport/DataChannel/DataChannel.cs
+++ b/csharp/src/Vista.SDK/Transport/DataChannel/DataChannel.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Vista.SDK.Transport.DataChannel;
@@ -330,19 +331,16 @@ public sealed record Restriction
                         return new ValidateResult.Invalid(["Value has more decimal places than allowed"]);
                     if (ValidateNumber((double)dec) is ValidateResult.Invalid invalid)
                         return invalid;
+                    if (ValidateTotalDigits(dec) is ValidateResult.Invalid totalDigitsInvalid)
+                        return totalDigitsInvalid;
                     return new ValidateResult.Ok();
                 },
                 i =>
                 {
                     if (ValidateNumber(i) is ValidateResult.Invalid invalid)
                         return invalid;
-                    if (TotalDigits is not null)
-                    {
-                        var numDigist = Math.Floor(Math.Log10(Math.Abs(i)) + 1) != TotalDigits;
-                        return new ValidateResult.Invalid(
-                            [$"Value {i} has {numDigist} digits but should be {TotalDigits}"]
-                        );
-                    }
+                    if (ValidateTotalDigits(i) is ValidateResult.Invalid totalDigitsInvalid)
+                        return totalDigitsInvalid;
                     return new ValidateResult.Ok();
                 },
                 b => new ValidateResult.Ok(),
@@ -353,14 +351,14 @@ public sealed record Restriction
                     if (Length is not null && length != Length)
                         return new ValidateResult.Invalid([$"Value {str} has length {length} but should be {Length}"]);
                     // check max length
-                    if (MaxLength is not null && length >= MaxLength)
+                    if (MaxLength is not null && length > MaxLength)
                         return new ValidateResult.Invalid(
-                            [$"Value {str} has length {length} but should be less than {MaxLength}"]
+                            [$"Value {str} has length {length} but should be at most {MaxLength}"]
                         );
                     // check min length
-                    if (MinLength is not null && length <= MinLength)
+                    if (MinLength is not null && length < MinLength)
                         return new ValidateResult.Invalid(
-                            [$"Value {str} has length {length} but should be greater than {MinLength}"]
+                            [$"Value {str} has length {length} but should be at least {MinLength}"]
                         );
                     // check pattern
                     if (Pattern is not null && !Regex.IsMatch(str, Pattern))
@@ -389,6 +387,30 @@ public sealed record Restriction
         if (MinInclusive is not null && number < MinInclusive)
             return new ValidateResult.Invalid([$"Value {number} is less than {MinInclusive}"]);
         return new ValidateResult.Ok();
+    }
+
+    private ValidateResult ValidateTotalDigits(decimal value)
+    {
+        if (TotalDigits is null)
+            return new ValidateResult.Ok();
+
+        var digits = CountTotalDigits(value);
+        if (digits != TotalDigits)
+            return new ValidateResult.Invalid([$"Value {value} has {digits} digits but should be {TotalDigits}"]);
+        return new ValidateResult.Ok();
+    }
+
+    private static int CountTotalDigits(decimal value)
+    {
+        value = Math.Abs(value);
+        if (value == 0m)
+            return 1;
+
+        var s = value.ToString(CultureInfo.InvariantCulture);
+        if (s.Contains('.'))
+            s = s.TrimEnd('0').TrimEnd('.');
+        s = s.Replace(".", string.Empty).TrimStart('0');
+        return s.Length == 0 ? 1 : s.Length;
     }
 
     private static decimal CountDecimalPlaces(decimal dec)

--- a/csharp/src/Vista.SDK/Transport/TimeSeriesData/TimeSeriesData.cs
+++ b/csharp/src/Vista.SDK/Transport/TimeSeriesData/TimeSeriesData.cs
@@ -144,61 +144,55 @@ public sealed record TimeSeriesData
                     }
                 }
             }
+        }
 
-            // Validate event data
-            if (EventData is not null)
+        // Validate event data
+        if (EventData is not null)
+        {
+            foreach (var eventData in EventData.DataSet ?? [])
             {
-                foreach (var eventData in EventData.DataSet ?? [])
-                {
-                    DataChannel.DataChannel? dataChannel = eventData
-                        .DataChannelId
-                        .Match(
-                            onLocalId: id =>
+                DataChannel.DataChannel? dataChannel = eventData
+                    .DataChannelId
+                    .Match(
+                        onLocalId: id =>
+                        {
+                            if (!dcPackage.Package.DataChannelList.TryGetByLocalId(id, out var dc) || dc is null)
                             {
-                                if (!dcPackage.Package.DataChannelList.TryGetByLocalId(id, out var dc) || dc is null)
-                                {
-                                    errorneousDataChannels.Add(
-                                        (eventData.DataChannelId, $"Data channel with localId '{id}' not found")
-                                    );
-                                    return null;
-                                }
-                                return dc;
-                            },
-                            onShortId: shortId =>
-                            {
-                                if (
-                                    !dcPackage.Package.DataChannelList.TryGetByShortId(shortId, out var dc)
-                                    || dc is null
-                                )
-                                {
-                                    errorneousDataChannels.Add(
-                                        (eventData.DataChannelId, $"Data channel with short id '{shortId}' not found")
-                                    );
-                                    return null;
-                                }
-                                return dc;
+                                errorneousDataChannels.Add(
+                                    (eventData.DataChannelId, $"Data channel with localId '{id}' not found")
+                                );
+                                return null;
                             }
-                        );
-                    if (dataChannel is null)
-                        continue;
+                            return dc;
+                        },
+                        onShortId: shortId =>
+                        {
+                            if (!dcPackage.Package.DataChannelList.TryGetByShortId(shortId, out var dc) || dc is null)
+                            {
+                                errorneousDataChannels.Add(
+                                    (eventData.DataChannelId, $"Data channel with short id '{shortId}' not found")
+                                );
+                                return null;
+                            }
+                            return dc;
+                        }
+                    );
+                if (dataChannel is null)
+                    continue;
 
-                    var typeValidation = dataChannel
-                        .Property
-                        .Format
-                        .ValidateValue(eventData.Value, out var parsedValue);
-                    if (typeValidation is ValidateResult.Invalid invalid)
-                    {
-                        errorneousDataChannels.Add((eventData.DataChannelId, string.Join(", ", invalid.Messages)));
-                        continue;
-                    }
+                var typeValidation = dataChannel.Property.Format.ValidateValue(eventData.Value, out var parsedValue);
+                if (typeValidation is ValidateResult.Invalid invalid)
+                {
+                    errorneousDataChannels.Add((eventData.DataChannelId, string.Join(", ", invalid.Messages)));
+                    continue;
+                }
 
-                    result = onEventData(eventData.TimeStamp, dataChannel, parsedValue, eventData.Quality);
+                var result = onEventData(eventData.TimeStamp, dataChannel, parsedValue, eventData.Quality);
 
-                    if (result is not ValidateResult.Ok)
-                    {
-                        errorneousDataChannels.Add((eventData.DataChannelId, result.ToString()));
-                        continue;
-                    }
+                if (result is not ValidateResult.Ok)
+                {
+                    errorneousDataChannels.Add((eventData.DataChannelId, result.ToString()));
+                    continue;
                 }
             }
         }

--- a/csharp/test/Vista.SDK.Tests/Transport/IsoMessageTests.TimeSeries.Validation.cs
+++ b/csharp/test/Vista.SDK.Tests/Transport/IsoMessageTests.TimeSeries.Validation.cs
@@ -1,0 +1,350 @@
+using FluentAssertions;
+using Vista.SDK.Transport;
+using Vista.SDK.Transport.Json;
+using Vista.SDK.Transport.TimeSeries;
+using DataChannel = Vista.SDK.Transport.DataChannel;
+
+namespace Vista.SDK.Tests.Transport;
+
+public partial class IsoMessageTests
+{
+    private const string RemoteSurveyDataChannelListJson = """
+        {
+            "Package": {
+                "Header": {
+                    "ShipID": "IMO9876543",
+                    "DataChannelListID": {
+                        "ID": "DCL-RS-1782743923921",
+                        "Version": "1",
+                        "TimeStamp": "2026-06-17T08:00:00+00:00"
+                    },
+                    "VersionInformation": {
+                        "NamingRule": "dnv",
+                        "NamingSchemeVersion": "v2",
+                        "ReferenceURL": "https://docs.vista.dnv.com"
+                    },
+                    "Author": "DNV Remote Survey",
+                    "DateCreated": "2026-06-17T08:00:00+00:00",
+                    "CustomHeaders": {
+                        "SurveyReference": "RS-2026-04711",
+                        "SurveyType": "Remote survey - drone",
+                        "DroneId": "ELIOS3-SN-88231",
+                        "DroneModel": "Flyability Elios 3",
+                        "DroneOperator": "ACME Robotics / J. Doe",
+                        "VisRelease": "3-11a"
+                    }
+                },
+                "DataChannelList": {
+                    "DataChannel": [
+                        {
+                            "DataChannelID": {
+                                "LocalID": "/dnv-v2/vis-3-10a/107.1/meta/detail-drone.visual.corrosion",
+                                "ShortID": "hull/drone/visual/inspection",
+                                "NameObject": {
+                                    "NamingRule": "/dnv-v2"
+                                }
+                            },
+                            "Property": {
+                                "DataChannelType": {
+                                    "Type": "Inst"
+                                },
+                                "Format": {
+                                    "Type": "String",
+                                    "Restriction": {
+                                        "Enumeration": [
+                                            "none",
+                                            "light",
+                                            "moderate",
+                                            "heavy",
+                                            "severe"
+                                        ]
+                                    }
+                                },
+                                "Unit": {
+                                    "UnitSymbol": "1",
+                                    "QuantityName": "corrosion.grade"
+                                },
+                                "Name": "Hull monitoring | drone visual inspection - corrosion grade",
+                                "Remarks": "Qualitative finding carried as an enumerated value (VIS codebooks do not standardize survey condition vocabulary)."
+                            }
+                        },
+                        {
+                            "DataChannelID": {
+                                "LocalID": "/dnv-v2/vis-3-10a/102.4/meta/detail-coating.breakdown",
+                                "ShortID": "coating/condition/breakdown.pct",
+                                "NameObject": {
+                                    "NamingRule": "/dnv-v2"
+                                }
+                            },
+                            "Property": {
+                                "DataChannelType": {
+                                    "Type": "Inst"
+                                },
+                                "Format": {
+                                    "Type": "Decimal",
+                                    "Restriction": {
+                                        "MaxInclusive": 100,
+                                        "MinInclusive": 0
+                                    }
+                                },
+                                "Range": {
+                                    "High": 100,
+                                    "Low": 0
+                                },
+                                "Unit": {
+                                    "UnitSymbol": "%",
+                                    "QuantityName": "coating.breakdown"
+                                },
+                                "Name": "Corrosion prevention monitoring | coating breakdown"
+                            }
+                        },
+                        {
+                            "DataChannelID": {
+                                "LocalID": "/dnv-v2/vis-3-10a/111/meta/qty-thickness/pos-port",
+                                "ShortID": "hull/structure/port/thickness",
+                                "NameObject": {
+                                    "NamingRule": "/dnv-v2"
+                                }
+                            },
+                            "Property": {
+                                "DataChannelType": {
+                                    "Type": "Inst"
+                                },
+                                "Format": {
+                                    "Type": "Decimal"
+                                },
+                                "Range": {
+                                    "High": 1000000,
+                                    "Low": 0
+                                },
+                                "Unit": {
+                                    "UnitSymbol": "mm",
+                                    "QuantityName": "thickness"
+                                },
+                                "Name": "Structural strength ship hull | port plate thickness (UT)"
+                            }
+                        },
+                        {
+                            "DataChannelID": {
+                                "LocalID": "/dnv-v2/vis-3-10a/1021.21/meta/qty-relative.humidity",
+                                "ShortID": "cargo.tank/atmosphere/humidity",
+                                "NameObject": {
+                                    "NamingRule": "/dnv-v2"
+                                }
+                            },
+                            "Property": {
+                                "DataChannelType": {
+                                    "Type": "Inst"
+                                },
+                                "Format": {
+                                    "Type": "Decimal"
+                                },
+                                "Range": {
+                                    "High": 1000000,
+                                    "Low": 0
+                                },
+                                "Unit": {
+                                    "UnitSymbol": "%",
+                                    "QuantityName": "relative.humidity"
+                                },
+                                "Name": "Cargo containment independent tank | atmosphere relative humidity"
+                            }
+                        },
+                        {
+                            "DataChannelID": {
+                                "LocalID": "/dnv-v2/vis-3-10a/085/meta/detail-video.report",
+                                "ShortID": "survey/report/video",
+                                "NameObject": {
+                                    "NamingRule": "/dnv-v2"
+                                }
+                            },
+                            "Property": {
+                                "DataChannelType": {
+                                    "Type": "Inst"
+                                },
+                                "Format": {
+                                    "Type": "String"
+                                },
+                                "Unit": {
+                                    "UnitSymbol": "1",
+                                    "QuantityName": "attachment.reference"
+                                },
+                                "Name": "Inspection reporting | recorded video evidence",
+                                "Remarks": "Value is the survey reference. The recorded video is uploaded as a binary attachment to this package; the attachment's ParentPackageId links it back to the survey."
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+        """;
+
+    private const string RemoteSurveyTimeSeriesDataJson = """
+        {
+            "Package": {
+                "Header": {
+                    "ShipID": "IMO9876543",
+                    "TimeSpan": {
+                        "Start": "2026-06-17T09:00:00+00:00",
+                        "End": "2026-06-17T09:20:00+00:00"
+                    },
+                    "DateCreated": "2026-06-17T09:25:00+00:00",
+                    "DateModified": "2026-06-17T09:25:00+00:00",
+                    "Author": "DNV Remote Survey - drone capture",
+                    "CustomHeaders": {
+                        "SurveyReference": "RS-2026-04711",
+                        "VideoFilename": "RS-2026-04711-hold3.mp4",
+                        "Note": "Each TimeStamp corresponds to a moment in the recorded video."
+                    }
+                },
+                "TimeSeriesData": [
+                    {
+                        "TabularData": [
+                            {
+                                "NumberOfDataSet": 3,
+                                "NumberOfDataChannel": 2,
+                                "DataChannelID": [
+                                    "hull/drone/visual/inspection",
+                                    "coating/condition/breakdown.pct"
+                                ],
+                                "DataSet": [
+                                    {
+                                        "TimeStamp": "2026-06-17T09:02:30+00:00",
+                                        "Value": [
+                                            "light",
+                                            "5.0"
+                                        ],
+                                        "Quality": [
+                                            "A",
+                                            "A"
+                                        ]
+                                    },
+                                    {
+                                        "TimeStamp": "2026-06-17T09:08:10+00:00",
+                                        "Value": [
+                                            "moderate",
+                                            "18.0"
+                                        ],
+                                        "Quality": [
+                                            "A",
+                                            "A"
+                                        ]
+                                    },
+                                    {
+                                        "TimeStamp": "2026-06-17T09:14:45+00:00",
+                                        "Value": [
+                                            "heavy",
+                                            "42.0"
+                                        ],
+                                        "Quality": [
+                                            "A",
+                                            "A"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "NumberOfDataSet": 2,
+                                "NumberOfDataChannel": 1,
+                                "DataChannelID": [
+                                    "hull/structure/port/thickness"
+                                ],
+                                "DataSet": [
+                                    {
+                                        "TimeStamp": "2026-06-17T09:08:10+00:00",
+                                        "Value": [
+                                            "14.6"
+                                        ],
+                                        "Quality": [
+                                            "A"
+                                        ]
+                                    },
+                                    {
+                                        "TimeStamp": "2026-06-17T09:14:45+00:00",
+                                        "Value": [
+                                            "12.1"
+                                        ],
+                                        "Quality": [
+                                            "A"
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "NumberOfDataSet": 1,
+                                "NumberOfDataChannel": 1,
+                                "DataChannelID": [
+                                    "cargo.tank/atmosphere/humidity"
+                                ],
+                                "DataSet": [
+                                    {
+                                        "TimeStamp": "2026-06-17T09:00:30+00:00",
+                                        "Value": [
+                                            "63.0"
+                                        ],
+                                        "Quality": [
+                                            "A"
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "EventData": {
+                            "NumberOfDataSet": 1,
+                            "DataSet": [
+                                {
+                                    "TimeStamp": "2026-06-17T09:20:00+00:00",
+                                    "DataChannelID": "survey/report/video",
+                                    "Value": "RS-2026-04711",
+                                    "Quality": "A"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        """;
+
+    [Fact]
+    public void Test_TimeSeriesData_Validation_RegistersAllDataChannels()
+    {
+        var dcDto = Serializer.DeserializeDataChannelList(RemoteSurveyDataChannelListJson);
+        dcDto.Should().NotBeNull();
+        var dcPackage = SDK.Transport.Json.DataChannel.Extensions.ToDomainModel(dcDto!);
+
+        var tsDto = Serializer.DeserializeTimeSeriesData(RemoteSurveyTimeSeriesDataJson);
+        tsDto.Should().NotBeNull();
+        var tsPackage = SDK.Transport.Json.TimeSeriesData.Extensions.ToDomainModel(tsDto!);
+
+        var registeredDataChannels = new Dictionary<string, DataChannel.DataChannel>();
+
+        ValidateData register = (timestamp, dataChannel, value, quality) =>
+        {
+            var key = dataChannel.DataChannelId.ShortId ?? dataChannel.DataChannelId.LocalId.ToString();
+            registeredDataChannels[key] = dataChannel;
+            return new ValidateResult.Ok();
+        };
+
+        foreach (var tsData in tsPackage.Package.TimeSeriesData)
+        {
+            var result = tsData.Validate(dcPackage, onTabularData: register, onEventData: register);
+
+            result.Should().BeOfType<ValidateResult.Ok>();
+        }
+
+        var expectedDataChannelIds = new[]
+        {
+            "hull/drone/visual/inspection",
+            "coating/condition/breakdown.pct",
+            "hull/structure/port/thickness",
+            "cargo.tank/atmosphere/humidity",
+            "survey/report/video"
+        };
+
+        registeredDataChannels.Should().HaveCount(5);
+        registeredDataChannels.Keys.Should().BeEquivalentTo(expectedDataChannelIds);
+    }
+}

--- a/csharp/test/Vista.SDK.Tests/Transport/RestrictionValidationTests.cs
+++ b/csharp/test/Vista.SDK.Tests/Transport/RestrictionValidationTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using Vista.SDK.Transport;
+using Vista.SDK.Transport.DataChannel;
+
+namespace Vista.SDK.Tests.Transport;
+
+public class RestrictionValidationTests
+{
+    private static Format FormatOf(string type) => new Format { Type = type, Restriction = null };
+
+    private static void AssertResult(ValidateResult result, bool expectedOk)
+    {
+        if (expectedOk)
+            result.Should().BeOfType<ValidateResult.Ok>();
+        else
+            result.Should().BeOfType<ValidateResult.Invalid>();
+    }
+
+    [Theory]
+    [InlineData(5, "12345", true)] // length == MaxLength is valid
+    [InlineData(5, "1234", true)] // below the limit is valid
+    [InlineData(5, "123456", false)] // above the limit is invalid
+    [InlineData(0, "", true)] // empty string with MaxLength 0
+    public void Test_MaxLength_Boundary(int maxLength, string value, bool expectedOk)
+    {
+        var restriction = new Restriction { MaxLength = (uint)maxLength };
+
+        var result = restriction.ValidateValue(value, FormatOf("String"));
+
+        AssertResult(result, expectedOk);
+    }
+
+    [Theory]
+    [InlineData(3, "123", true)] // length == MinLength is valid
+    [InlineData(3, "1234", true)] // above the limit is valid
+    [InlineData(3, "12", false)] // below the limit is invalid
+    public void Test_MinLength_Boundary(int minLength, string value, bool expectedOk)
+    {
+        var restriction = new Restriction { MinLength = (uint)minLength };
+
+        var result = restriction.ValidateValue(value, FormatOf("String"));
+
+        AssertResult(result, expectedOk);
+    }
+
+    [Theory]
+    [InlineData(3, "123", true)] // exact digit count is valid
+    [InlineData(3, "12", false)] // too few digits is invalid
+    [InlineData(3, "1234", false)] // too many digits is invalid
+    [InlineData(3, "100", true)] // trailing zeros in the integer part count
+    [InlineData(1, "0", true)] // zero counts as a single digit
+    public void Test_TotalDigits_Integer(int totalDigits, string value, bool expectedOk)
+    {
+        var restriction = new Restriction { TotalDigits = (uint)totalDigits };
+
+        var result = restriction.ValidateValue(value, FormatOf("Integer"));
+
+        AssertResult(result, expectedOk);
+    }
+
+    [Theory]
+    [InlineData(3, "12.3", true)] // 3 significant digits
+    [InlineData(3, "1.23", true)] // 3 significant digits
+    [InlineData(3, "0.045", false)] // only 2 significant digits
+    [InlineData(2, "0.045", true)] // leading zeros do not count
+    [InlineData(3, "12.34", false)] // 4 significant digits is invalid
+    [InlineData(3, "12.30", true)] // trailing fractional zeros do not count
+    public void Test_TotalDigits_Decimal(int totalDigits, string value, bool expectedOk)
+    {
+        var restriction = new Restriction { TotalDigits = (uint)totalDigits };
+
+        var result = restriction.ValidateValue(value, FormatOf("Decimal"));
+
+        AssertResult(result, expectedOk);
+    }
+}

--- a/python/src/vista_sdk/transport/data_channel/data_channel.py
+++ b/python/src/vista_sdk/transport/data_channel/data_channel.py
@@ -495,7 +495,19 @@ class Restriction:
             decimal_places = self._count_decimal_places(str(dec))
             if decimal_places > self.fraction_digits:
                 return Invalid(["Value has more decimal places than allowed"])
-        return self._validate_number(float(dec))
+        number_result = self._validate_number(float(dec))
+        if isinstance(number_result, Invalid):
+            return number_result
+        if self.total_digits is not None:
+            num_digits = self._count_total_digits(dec)
+            if num_digits != self.total_digits:
+                return Invalid(
+                    [
+                        f"Value {dec} has {num_digits} digits "
+                        f"but should be {self.total_digits}"
+                    ]
+                )
+        return Ok()
 
     def _validate_integer_value(self, i: int) -> ValidateResult:
         """Validate integer value against restrictions."""
@@ -520,18 +532,18 @@ class Restriction:
             return Invalid(
                 [f"Value {value} has length {length} but should be {self.length}"]
             )
-        if self.max_length is not None and length >= self.max_length:
+        if self.max_length is not None and length > self.max_length:
             return Invalid(
                 [
                     f"Value {value} has length {length} "
-                    f"but should be less than {self.max_length}"
+                    f"but should be at most {self.max_length}"
                 ]
             )
-        if self.min_length is not None and length <= self.min_length:
+        if self.min_length is not None and length < self.min_length:
             return Invalid(
                 [
                     f"Value {value} has length {length} "
-                    f"but should be greater than {self.min_length}"
+                    f"but should be at least {self.min_length}"
                 ]
             )
         if self.pattern is not None and not re.match(self.pattern, value):
@@ -560,6 +572,20 @@ class Restriction:
         if "." not in value:
             return 0
         return len(value.split(".")[1])
+
+    def _count_total_digits(self, value: float) -> int:
+        """Count the total number of significant digits in a numeric value.
+
+        Mirrors XSD totalDigits semantics: leading zeros and trailing
+        fractional zeros are not counted, trailing integer zeros are.
+        """
+        s = repr(abs(value))
+        if "e" in s or "E" in s:
+            s = f"{abs(value):.20f}"
+        if "." in s:
+            s = s.rstrip("0").rstrip(".")
+        s = s.replace(".", "").lstrip("0")
+        return len(s) if s else 1
 
 
 class WhiteSpace(Enum):

--- a/python/tests/transport/test_transport_data_channel.py
+++ b/python/tests/transport/test_transport_data_channel.py
@@ -223,6 +223,80 @@ def test_restriction() -> None:
     assert isinstance(result, Invalid)
 
 
+@pytest.mark.parametrize(
+    ("max_length", "value", "expected_ok"),
+    [
+        (5, "12345", True),  # length == max_length is valid
+        (5, "1234", True),  # below the limit is valid
+        (5, "123456", False),  # above the limit is invalid
+        (0, "", True),  # empty string with max_length 0
+    ],
+)
+def test_restriction_max_length_boundary(
+    max_length: int, value: str, expected_ok: bool
+) -> None:
+    """max_length should accept values exactly at the limit."""
+    restriction = Restriction(max_length=max_length)
+    result = restriction.validate_value(value, Format("String"))
+    assert isinstance(result, Ok if expected_ok else Invalid)
+
+
+@pytest.mark.parametrize(
+    ("min_length", "value", "expected_ok"),
+    [
+        (3, "123", True),  # length == min_length is valid
+        (3, "1234", True),  # above the limit is valid
+        (3, "12", False),  # below the limit is invalid
+    ],
+)
+def test_restriction_min_length_boundary(
+    min_length: int, value: str, expected_ok: bool
+) -> None:
+    """min_length should accept values exactly at the limit."""
+    restriction = Restriction(min_length=min_length)
+    result = restriction.validate_value(value, Format("String"))
+    assert isinstance(result, Ok if expected_ok else Invalid)
+
+
+@pytest.mark.parametrize(
+    ("total_digits", "value", "expected_ok"),
+    [
+        (3, "123", True),  # exact digit count is valid
+        (3, "12", False),  # too few digits is invalid
+        (3, "1234", False),  # too many digits is invalid
+        (3, "100", True),  # trailing zeros in the integer part count
+        (1, "0", True),  # zero counts as a single digit
+    ],
+)
+def test_restriction_total_digits_integer(
+    total_digits: int, value: str, expected_ok: bool
+) -> None:
+    """total_digits should match the exact digit count for integers."""
+    restriction = Restriction(total_digits=total_digits)
+    result = restriction.validate_value(value, Format("Integer"))
+    assert isinstance(result, Ok if expected_ok else Invalid)
+
+
+@pytest.mark.parametrize(
+    ("total_digits", "value", "expected_ok"),
+    [
+        (3, "12.3", True),  # 3 significant digits
+        (3, "1.23", True),  # 3 significant digits
+        (3, "0.045", False),  # only 2 significant digits
+        (2, "0.045", True),  # leading zeros do not count
+        (3, "12.34", False),  # 4 significant digits is invalid
+        (3, "12.30", True),  # trailing fractional zeros do not count
+    ],
+)
+def test_restriction_total_digits_decimal(
+    total_digits: int, value: str, expected_ok: bool
+) -> None:
+    """total_digits should be enforced for decimal values."""
+    restriction = Restriction(total_digits=total_digits)
+    result = restriction.validate_value(value, Format("Decimal"))
+    assert isinstance(result, Ok if expected_ok else Invalid)
+
+
 def test_range() -> None:
     """Test Range creation and validation."""
     # Test valid range


### PR DESCRIPTION
### TimeSeriesData validation bug fixes
* C# Event data validation was improperly invoked inside the tabular data scope
* C#, Py: Restriction properties max lengths were off by one