### PR TITLE
Fix invalid ISO 19848 short paths in GmodSubset samples across Python, JS and C#

### DIFF
--- a/csharp/samples/GmodSubset/Program.cs
+++ b/csharp/samples/GmodSubset/Program.cs
@@ -47,21 +47,21 @@ void ExampleDualEngineVessel()
     string[] assetPaths =
     [
         // === Port Main Engine (411.1-P) with 6 cylinders ===
-        "411.1-P/C101/C101.31-1", // Port engine, cylinder 1
-        "411.1-P/C101/C101.31-2", // Port engine, cylinder 2
-        "411.1-P/C101/C101.31-3", // Port engine, cylinder 3
-        "411.1-P/C101/C101.31-4", // Port engine, cylinder 4
-        "411.1-P/C101/C101.31-5", // Port engine, cylinder 5
-        "411.1-P/C101/C101.31-6", // Port engine, cylinder 6
-        "411.1-P/C101/C101.63/S206", // Port engine, cooling system
+        "411.1-P/C101.31-1", // Port engine, cylinder 1
+        "411.1-P/C101.31-2", // Port engine, cylinder 2
+        "411.1-P/C101.31-3", // Port engine, cylinder 3
+        "411.1-P/C101.31-4", // Port engine, cylinder 4
+        "411.1-P/C101.31-5", // Port engine, cylinder 5
+        "411.1-P/C101.31-6", // Port engine, cylinder 6
+        "411.1-P/C101.63/S206", // Port engine, cooling system
         // === Starboard Main Engine (411.1-S) with 6 cylinders ===
-        "411.1-S/C101/C101.31-1", // Starboard engine, cylinder 1
-        "411.1-S/C101/C101.31-2", // Starboard engine, cylinder 2
-        "411.1-S/C101/C101.31-3", // Starboard engine, cylinder 3
-        "411.1-S/C101/C101.31-4", // Starboard engine, cylinder 4
-        "411.1-S/C101/C101.31-5", // Starboard engine, cylinder 5
-        "411.1-S/C101/C101.31-6", // Starboard engine, cylinder 6
-        "411.1-S/C101/C101.63/S206", // Starboard engine, cooling system
+        "411.1-S/C101.31-1", // Starboard engine, cylinder 1
+        "411.1-S/C101.31-2", // Starboard engine, cylinder 2
+        "411.1-S/C101.31-3", // Starboard engine, cylinder 3
+        "411.1-S/C101.31-4", // Starboard engine, cylinder 4
+        "411.1-S/C101.31-5", // Starboard engine, cylinder 5
+        "411.1-S/C101.31-6", // Starboard engine, cylinder 6
+        "411.1-S/C101.63/S206", // Starboard engine, cooling system
         // === Generator Sets ===
         "511.11-1/C101", // Generator 1, diesel engine
         "511.11-2/C101", // Generator 2, diesel engine
@@ -174,7 +174,7 @@ void ExampleJsonExport()
     var visVersion = VisVersion.v3_4a;
 
     // Small example for readable JSON
-    string[] assetPaths = ["411.1/C101/C101.31-1", "411.1/C101/C101.31-2"];
+    string[] assetPaths = ["411.1/C101.31-1", "411.1/C101.31-2"];
 
     var model = AssetModel.FromPathStrings(visVersion, assetPaths);
 
@@ -243,7 +243,7 @@ sealed class AssetNode
     {
         var prefix = new string(' ', indent * 2);
         var connector = indent > 0 ? "├─" : "";
-        var displayName = _displayName;
+        var displayName = _displayName ?? Node.Metadata.CommonName ?? Node.Metadata.Name;
         var location = Node.Location is not null ? $" [{Node.Location}]" : "";
         Console.WriteLine($"{prefix}{connector} {Node.Code}{location}: {displayName}");
         foreach (var child in Children.OrderBy(c => c.Path?.ToString()).Where(c => c.Path is not null))

--- a/js/samples/GmodSubset.ts
+++ b/js/samples/GmodSubset.ts
@@ -230,21 +230,21 @@ async function exampleDualEngineVessel(): Promise<void> {
     // Define the equipment that exists on this vessel
     const assetPaths = [
         // === Port Main Engine (411.1-P) with 6 cylinders ===
-        "411.1-P/C101/C101.31-1", // Port engine, cylinder 1
-        "411.1-P/C101/C101.31-2", // Port engine, cylinder 2
-        "411.1-P/C101/C101.31-3", // Port engine, cylinder 3
-        "411.1-P/C101/C101.31-4", // Port engine, cylinder 4
-        "411.1-P/C101/C101.31-5", // Port engine, cylinder 5
-        "411.1-P/C101/C101.31-6", // Port engine, cylinder 6
-        "411.1-P/C101/C101.63/S206", // Port engine, cooling system
+        "411.1-P/C101.31-1", // Port engine, cylinder 1
+        "411.1-P/C101.31-2", // Port engine, cylinder 2
+        "411.1-P/C101.31-3", // Port engine, cylinder 3
+        "411.1-P/C101.31-4", // Port engine, cylinder 4
+        "411.1-P/C101.31-5", // Port engine, cylinder 5
+        "411.1-P/C101.31-6", // Port engine, cylinder 6
+        "411.1-P/C101.63/S206", // Port engine, cooling system
         // === Starboard Main Engine (411.1-S) with 6 cylinders ===
-        "411.1-S/C101/C101.31-1", // Starboard engine, cylinder 1
-        "411.1-S/C101/C101.31-2", // Starboard engine, cylinder 2
-        "411.1-S/C101/C101.31-3", // Starboard engine, cylinder 3
-        "411.1-S/C101/C101.31-4", // Starboard engine, cylinder 4
-        "411.1-S/C101/C101.31-5", // Starboard engine, cylinder 5
-        "411.1-S/C101/C101.31-6", // Starboard engine, cylinder 6
-        "411.1-S/C101/C101.63/S206", // Starboard engine, cooling system
+        "411.1-S/C101.31-1", // Starboard engine, cylinder 1
+        "411.1-S/C101.31-2", // Starboard engine, cylinder 2
+        "411.1-S/C101.31-3", // Starboard engine, cylinder 3
+        "411.1-S/C101.31-4", // Starboard engine, cylinder 4
+        "411.1-S/C101.31-5", // Starboard engine, cylinder 5
+        "411.1-S/C101.31-6", // Starboard engine, cylinder 6
+        "411.1-S/C101.63/S206", // Starboard engine, cooling system
         // === Generator Sets ===
         "511.11-1/C101", // Generator 1, diesel engine
         "511.11-2/C101", // Generator 2, diesel engine
@@ -352,7 +352,7 @@ async function exampleJsonExport(): Promise<void> {
     const visVersion = VisVersion.v3_4a;
 
     // Small example for readable JSON
-    const assetPaths = ["411.1/C101/C101.31-1", "411.1/C101/C101.31-2"];
+    const assetPaths = ['411.1/C101.31-1', '411.1/C101.31-2'];
 
     const model = await AssetModel.fromPathStrings(visVersion, assetPaths);
 

--- a/python/samples/gmod_subset.py
+++ b/python/samples/gmod_subset.py
@@ -279,21 +279,21 @@ def example_dual_engine_vessel() -> None:
     # Each path is a "leaf" item e.g. ISO19848 Annex C short path - the full hierarchy is implicit  # noqa: E501
     asset_paths = [
         # === Port Main Engine (411.1-P) with 6 cylinders ===
-        "411.1-P/C101/C101.31-1",  # Port engine, cylinder 1
-        "411.1-P/C101/C101.31-2",  # Port engine, cylinder 2
-        "411.1-P/C101/C101.31-3",  # Port engine, cylinder 3
-        "411.1-P/C101/C101.31-4",  # Port engine, cylinder 4
-        "411.1-P/C101/C101.31-5",  # Port engine, cylinder 5
-        "411.1-P/C101/C101.31-6",  # Port engine, cylinder 6
-        "411.1-P/C101/C101.63/S206",  # Port engine, cooling system
+        "411.1-P/C101.31-1",  # Port engine, cylinder 1
+        "411.1-P/C101.31-2",  # Port engine, cylinder 2
+        "411.1-P/C101.31-3",  # Port engine, cylinder 3
+        "411.1-P/C101.31-4",  # Port engine, cylinder 4
+        "411.1-P/C101.31-5",  # Port engine, cylinder 5
+        "411.1-P/C101.31-6",  # Port engine, cylinder 6
+        "411.1-P/C101.63/S206",  # Port engine, cooling system
         # === Starboard Main Engine (411.1-S) with 6 cylinders ===
-        "411.1-S/C101/C101.31-1",  # Starboard engine, cylinder 1
-        "411.1-S/C101/C101.31-2",  # Starboard engine, cylinder 2
-        "411.1-S/C101/C101.31-3",  # Starboard engine, cylinder 3
-        "411.1-S/C101/C101.31-4",  # Starboard engine, cylinder 4
-        "411.1-S/C101/C101.31-5",  # Starboard engine, cylinder 5
-        "411.1-S/C101/C101.31-6",  # Starboard engine, cylinder 6
-        "411.1-S/C101/C101.63/S206",  # Starboard engine, cooling system
+        "411.1-S/C101.31-1",  # Starboard engine, cylinder 1
+        "411.1-S/C101.31-2",  # Starboard engine, cylinder 2
+        "411.1-S/C101.31-3",  # Starboard engine, cylinder 3
+        "411.1-S/C101.31-4",  # Starboard engine, cylinder 4
+        "411.1-S/C101.31-5",  # Starboard engine, cylinder 5
+        "411.1-S/C101.31-6",  # Starboard engine, cylinder 6
+        "411.1-S/C101.63/S206",  # Starboard engine, cooling system
         # === Generator Sets ===
         "511.11-1/C101",  # Generator 1, diesel engine
         "511.11-2/C101",  # Generator 2, diesel engine
@@ -351,8 +351,8 @@ def example_json_export() -> None:
 
     # Small example for readable JSON
     asset_paths = [
-        "411.1/C101/C101.31-1",
-        "411.1/C101/C101.31-2",
+        "411.1/C101.31-1",
+        "411.1/C101.31-2",
     ]
 
     model = AssetModel.from_path_strings(vis_version, asset_paths)
@@ -435,3 +435,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
Hi,

Small fix here.

These paths were silently accepted before f794276 tightened the parser.